### PR TITLE
feat: add `MarkdownExitEnv` type and set a empty `env` for parser and renderer

### DIFF
--- a/packages/markdown-exit/src/index.ts
+++ b/packages/markdown-exit/src/index.ts
@@ -2,6 +2,7 @@
 
 import type Token from './token'
 import type { Preset } from './types/preset'
+import type { MarkdownExitEnv } from './types/shared'
 import LinkifyIt from 'linkify-it'
 import * as mdurl from 'mdurl'
 import punycode from 'punycode.js'
@@ -11,7 +12,6 @@ import ParserBlock from './parser_block'
 import ParserCore from './parser_core'
 import ParserInline from './parser_inline'
 import cfg_commonmark from './presets/commonmark'
-
 import cfg_default from './presets/default'
 import cfg_zero from './presets/zero'
 import Renderer from './renderer'
@@ -444,7 +444,7 @@ export class MarkdownExit {
    * @param src source string
    * @param env environment sandbox
    */
-  parse(src: string, env?: any): Token[] {
+  parse(src: string, env: MarkdownExitEnv = {}): Token[] {
     if (typeof src !== 'string') {
       throw new TypeError('Input data should be a String')
     }
@@ -466,9 +466,7 @@ export class MarkdownExit {
    * @param src source string
    * @param env environment sandbox
    */
-  render(src: string, env?: any): string {
-    env = env || {}
-
+  render(src: string, env: MarkdownExitEnv = {}): string {
     return this.renderer.render(this.parse(src, env), this.options, env)
   }
 
@@ -482,7 +480,7 @@ export class MarkdownExit {
    * @param src source string
    * @param env environment sandbox
    */
-  parseInline(src: string, env?: any): Token[] {
+  parseInline(src: string, env: MarkdownExitEnv = {}): Token[] {
     const state = new this.core.State(src, this, env)
 
     state.inlineMode = true
@@ -498,9 +496,7 @@ export class MarkdownExit {
    * @param src source string
    * @param env environment sandbox
    */
-  renderInline(src: string, env?: any): string {
-    env = env || {}
-
+  renderInline(src: string, env: MarkdownExitEnv = {}): string {
     return this.renderer.render(this.parseInline(src, env), this.options, env)
   }
 }

--- a/packages/markdown-exit/src/parser_block.ts
+++ b/packages/markdown-exit/src/parser_block.ts
@@ -8,6 +8,7 @@
 import type { MarkdownExit } from '.'
 import type Token from './token'
 
+import type { MarkdownExitEnv } from './types/shared'
 import Ruler from './ruler'
 import r_blockquote from './rules_block/blockquote'
 import r_code from './rules_block/code'
@@ -129,7 +130,7 @@ export default class ParserBlock {
   /**
    * Process input string and push block tokens into `outTokens`
    */
-  parse(src: string, md: MarkdownExit, env: any, outTokens: Token[]) {
+  parse(src: string, md: MarkdownExit, env: MarkdownExitEnv, outTokens: Token[]) {
     if (!src)
       return
 

--- a/packages/markdown-exit/src/parser_inline.ts
+++ b/packages/markdown-exit/src/parser_inline.ts
@@ -7,6 +7,7 @@
 
 import type { MarkdownExit } from '.'
 import type Token from './token'
+import type { MarkdownExitEnv } from './types/shared'
 import Ruler from './ruler'
 import r_autolink from './rules_inline/autolink'
 import r_backticks from './rules_inline/backticks'
@@ -21,7 +22,6 @@ import r_link from './rules_inline/link'
 import r_linkify from './rules_inline/linkify'
 import r_newline from './rules_inline/newline'
 import StateInline from './rules_inline/state_inline'
-
 import r_strikethrough from './rules_inline/strikethrough'
 import r_text from './rules_inline/text'
 
@@ -202,7 +202,7 @@ export default class ParserInline {
   /**
    * Process input string and push inline tokens into `outTokens`
    */
-  parse(str: string, md: MarkdownExit, env: any, outTokens: Token[]) {
+  parse(str: string, md: MarkdownExit, env: MarkdownExitEnv, outTokens: Token[]) {
     const state = new this.State(str, md, env, outTokens)
 
     this.tokenize(state)

--- a/packages/markdown-exit/src/renderer.ts
+++ b/packages/markdown-exit/src/renderer.ts
@@ -9,9 +9,10 @@
 import type { Options } from '.'
 import type Token from './token'
 import type { HTMLAttribute } from './token'
+import type { MarkdownExitEnv } from './types/shared'
 import { escapeHtml, unescapeAll } from './common/utils'
 
-export type RenderRule = (tokens: Token[], idx: number, options: Options, env: any, self: Renderer) => string
+export type RenderRule = (tokens: Token[], idx: number, options: Options, env: MarkdownExitEnv, self: Renderer) => string
 
 export interface RenderRuleRecord {
   [type: string]: RenderRule | undefined
@@ -175,7 +176,7 @@ export default class Renderer {
    * @param env additional data from parsed input (references, for example)
    */
   // eslint-disable-next-line unused-imports/no-unused-vars
-  renderToken(tokens: Token[], idx: number, options: Options, env?: any): string {
+  renderToken(tokens: Token[], idx: number, options: Options, env: MarkdownExitEnv = {}): string {
     const token = tokens[idx]
     let result = ''
 
@@ -240,7 +241,7 @@ export default class Renderer {
    * @param options params of parser instance
    * @param env additional data from parsed input (references, for example)
    */
-  renderInline(tokens: Token[], options: Options, env?: any): string {
+  renderInline(tokens: Token[], options: Options, env: MarkdownExitEnv = {}): string {
     let result = ''
     const rules = this.rules
 
@@ -266,7 +267,7 @@ export default class Renderer {
    * @param options params of parser instance
    * @param env additional data from parsed input (references, for example)
    */
-  renderInlineAsText(tokens: Token[], options: Options, env?: any): string {
+  renderInlineAsText(tokens: Token[], options: Options, env: MarkdownExitEnv = {}): string {
     let result = ''
 
     for (let i = 0, len = tokens.length; i < len; i++) {
@@ -301,7 +302,7 @@ export default class Renderer {
    * @param options params of parser instance
    * @param env additional data from parsed input (references, for example)
    */
-  render(tokens: Token[], options: Options, env?: any): string {
+  render(tokens: Token[], options: Options, env: MarkdownExitEnv = {}): string {
     let result = ''
     const rules = this.rules
 

--- a/packages/markdown-exit/src/rules_block/state_block.ts
+++ b/packages/markdown-exit/src/rules_block/state_block.ts
@@ -8,6 +8,7 @@
 import type { MarkdownExit } from '..'
 import type { BlockRule } from '../parser_block'
 import type { Nesting } from '../token'
+import type { MarkdownExitEnv } from '../types/shared'
 import { isSpace } from '../common/utils'
 import Token from '../token'
 
@@ -21,7 +22,7 @@ export default class StateBlock {
    */
   md: MarkdownExit
 
-  env: any
+  env: MarkdownExitEnv
 
   //
   // Internal state vartiables
@@ -96,7 +97,7 @@ export default class StateBlock {
 
   static Token: typeof Token = Token
 
-  constructor(src: string, md: MarkdownExit, env: any, tokens: Token[]) {
+  constructor(src: string, md: MarkdownExit, env: MarkdownExitEnv, tokens: Token[]) {
     this.src = src
     this.md = md
     this.env = env

--- a/packages/markdown-exit/src/rules_core/state_core.ts
+++ b/packages/markdown-exit/src/rules_core/state_core.ts
@@ -2,11 +2,12 @@
 //
 
 import type { MarkdownExit } from '..'
+import type { MarkdownExitEnv } from '../types/shared'
 import Token from '../token'
 
 export default class StateCore {
   src: string
-  env: any
+  env: MarkdownExitEnv
   tokens: Token[] = []
   inlineMode: boolean = false
 
@@ -15,7 +16,7 @@ export default class StateCore {
    */
   md: MarkdownExit
 
-  constructor(src: string, md: MarkdownExit, env: any) {
+  constructor(src: string, md: MarkdownExit, env: MarkdownExitEnv) {
     this.src = src
     this.env = env
     this.md = md

--- a/packages/markdown-exit/src/rules_inline/state_inline.ts
+++ b/packages/markdown-exit/src/rules_inline/state_inline.ts
@@ -7,6 +7,7 @@
 
 import type { MarkdownExit } from '..'
 import type { Nesting } from '../token'
+import type { MarkdownExitEnv } from '../types/shared'
 import { isMdAsciiPunct, isPunctChar, isWhiteSpace } from '../common/utils'
 import Token from '../token'
 
@@ -31,7 +32,7 @@ export interface TokenMeta {
 
 export default class StateInline {
   src: string
-  env: any
+  env: MarkdownExitEnv
   md: MarkdownExit
   tokens: Token[]
   tokens_meta: Array<TokenMeta | null>
@@ -70,7 +71,7 @@ export default class StateInline {
    */
   linkLevel: number = 0
 
-  constructor(src: string, md: MarkdownExit, env: any, outTokens: Token[]) {
+  constructor(src: string, md: MarkdownExit, env: MarkdownExitEnv, outTokens: Token[]) {
     this.src = src
     this.env = env
     this.md = md

--- a/packages/markdown-exit/src/types/shared.d.ts
+++ b/packages/markdown-exit/src/types/shared.d.ts
@@ -1,0 +1,8 @@
+export interface MarkdownExitEnv {
+  references?: Record<string, {
+    title: string
+    href: string
+  }>
+
+  [key: string]: any
+}

--- a/packages/markdown-exit/tests/parser.test.ts
+++ b/packages/markdown-exit/tests/parser.test.ts
@@ -1,0 +1,31 @@
+import { assert, describe, expect, it } from 'vitest'
+import markdownit from '../src'
+
+describe('parse reference-style links', () => {
+  it('without env param (issue #6)', () => {
+    const md = markdownit()
+    const result = md.parse(`[hobbit-hole][1]
+
+[1]: https://en.wikipedia.org/wiki/Hobbit#Lifestyle "Hobbit lifestyles"`)
+    expect(result).toBeTruthy()
+  })
+
+  it('able to write input env', () => {
+    const md = markdownit()
+    const env = {}
+    const result = md.parse(`[hobbit-hole][1]
+
+[1]: https://en.wikipedia.org/wiki/Hobbit#Lifestyle "Hobbit lifestyles"`, env)
+    expect(result).toBeTruthy()
+    expect(env).toMatchInlineSnapshot(`
+      {
+        "references": {
+          "1": {
+            "href": "https://en.wikipedia.org/wiki/Hobbit#Lifestyle",
+            "title": "Hobbit lifestyles",
+          },
+        },
+      }
+    `)
+  })
+})


### PR DESCRIPTION
Fixed #6