### PR TITLE
docs: fix broken documentation link for 'language-neutral replacement'

### DIFF
--- a/packages/markdown-exit/src/parser/parser.ts
+++ b/packages/markdown-exit/src/parser/parser.ts
@@ -23,7 +23,7 @@ export interface ParserOptions {
   linkify?: boolean
 
   /**
-   * Set `true` to enable [some language-neutral replacement](https://github.com/serkodev/markdown-exit/tree/main/packages/markdown-exit/src/rules_core/replacements.ts) +
+   * Set `true` to enable [some language-neutral replacement](https://github.com/serkodev/markdown-exit/blob/main/packages/markdown-exit/src/parser/core/rules/replacements.ts) +
    * quotes beautification (smartquotes).
    * @default false
    */


### PR DESCRIPTION
https://markdown-exit.pages.dev/reference/api/Interface.MarkdownExitOptions.html#typographer

Docuementation of `Interface.MarkdownExitOptions.html#typographer` has broken link for `some language-neutral replacement`. It should link to replacements.ts, but it didn't get updated at 91f6f57.

Updated the link to replacements.ts.