### PR TITLE
docs(plugins): add markdown-exit-image plugin

### DIFF
--- a/docs/guide/plugins.md
+++ b/docs/guide/plugins.md
@@ -37,6 +37,12 @@ Thanks to the [markdown-it](https://github.com/markdown-it) community has develo
 
 Browse all markdown-it plugins on the [npm](https://www.npmjs.org/browse/keyword/markdown-it-plugin).
 
+## Plugins for markdown-exit
+
+The community is also developing plugins specifically for **markdown-exit** by taking advantage of its unique features, such as async rendering:
+
+- [markdown-exit-image](https://github.com/barbapapazes/markdown-exit-image)
+
 ## Plugin Development
 
 As **markdown-it** plugins are supported, it’s recommended to read the [markdown-it architecture](https://github.com/markdown-it/markdown-it/blob/d2782d892a51201b25d3eeab172201ad5a53a24c/docs/architecture.md) before starting plugin development.


### PR DESCRIPTION
Hello 👋,

I've created a plugin for Markdown Exit to automatically optimize images. It's basic for now but more features are planned.

It's based on an article I wrote: https://soubiran.dev/posts/markdown-exit-breaks-the-rules-with-async-rendering