### PR TITLE
docs: add mdit-plugins in docs

### DIFF
--- a/docs/guide/plugins.md
+++ b/docs/guide/plugins.md
@@ -33,9 +33,12 @@ Thanks to the [markdown-it](https://github.com/markdown-it) community has develo
 - [markdown-it-container](https://github.com/markdown-it/markdown-it-container)
 - [markdown-it-ins](https://github.com/markdown-it/markdown-it-ins)
 - [markdown-it-mark](https://github.com/markdown-it/markdown-it-mark)
-- [mdit-plugins](https://github.com/mdit-plugins/mdit-plugins) - A collection of various markdown-it plugins written in TypeScript.
 
 Browse all markdown-it plugins on the [npm](https://www.npmjs.org/browse/keyword/markdown-it-plugin).
+
+### Community
+
+- [mdit-plugins](https://github.com/mdit-plugins/mdit-plugins) - A collection of various markdown-it plugins written in TypeScript.
 
 ## Plugins for markdown-exit
 


### PR DESCRIPTION
I would like to add a promotion here for mdit-plugins, as this does similar thing for `markdown-exit` -> `markdown-it`:

- it rewrites all official plugins in typescript, adds 100% coverage for then (I will lift the coverage again from 99% very soon), and maximum their performance (all the same or better than the original one).

- it also adds various new plugins for markdown-it community and also for VuePress v2, e.g.: the `plugin-tex` `plugin-katex` and `plugin-mathjax`, more modern (e.g.: mathjax v4 support) and more performant then any exisiting community plugins
