### PR TITLE
fix: backport ReDoS fix from markdown-it in linkify inline parser (CVE-2026-2327)

### DIFF
--- a/packages/markdown-exit/src/parser/inline/rules/linkify.ts
+++ b/packages/markdown-exit/src/parser/inline/rules/linkify.ts
@@ -41,7 +41,14 @@ export default function linkify(state: StateInline, silent: boolean) {
     return false
 
   // disallow '*' at the end of the link (conflicts with emphasis)
-  url = url.replace(/\*+$/, '')
+  // do manual backsearch to avoid perf issues with regex /\*+$/ on "****...****a".
+  let urlEnd = url.length
+  while (urlEnd > 0 && url.charCodeAt(urlEnd - 1) === 0x2A/* * */) {
+    urlEnd--
+  }
+  if (urlEnd !== url.length) {
+    url = url.slice(0, urlEnd)
+  }
 
   const fullUrl = state.md.normalizeLink(url)
   if (!state.md.validateLink(fullUrl))

--- a/packages/markdown-exit/tests/pathological.test.ts
+++ b/packages/markdown-exit/tests/pathological.test.ts
@@ -129,7 +129,8 @@ describe('markdown-it', () => {
   it('linkify trailing asterisks pattern (CVE-2026-2327)', () => {
     const md = MarkdownExit({ linkify: true })
     // This pattern would cause ReDoS with the old regex implementation
+    // https://github.com/markdown-it/markdown-it/commit/4b4bbcae5e0990a5b172378e507b33a59012ed26
     const result = md.render('https://test.com?' + '*'.repeat(70000) + 'a')
     expect(result).toBeTruthy()
-  })
+  }, 500)
 })

--- a/packages/markdown-exit/tests/pathological.test.ts
+++ b/packages/markdown-exit/tests/pathological.test.ts
@@ -125,4 +125,11 @@ describe('markdown-it', () => {
   it('hardbreak whitespaces pattern', () => {
     test_pattern('x' + ' '.repeat(150000) + 'x  \nx')
   })
+
+  it('linkify trailing asterisks pattern (CVE-2026-2327)', () => {
+    const md = MarkdownExit({ linkify: true })
+    // This pattern would cause ReDoS with the old regex implementation
+    const result = md.render('https://test.com?' + '*'.repeat(70000) + 'a')
+    expect(result).toBeTruthy()
+  })
 })


### PR DESCRIPTION
- https://github.com/markdown-it/markdown-it/commit/4b4bbcae5e0990a5b172378e507b33a59012ed26
- https://github.com/markdown-it/markdown-it/blob/master/CHANGELOG.md#1411---2026-01-11
- https://github.com/advisories/GHSA-38c4-r59v-3vqw

This task takes more than 3 seconds:

```ts
import mdit from "markdown-exit";
mdit({linkify:true}).render("http://example.com/" + "*".repeat(70000) + "a");
```

due to the fact that the following expression

```ts
("*".repeat(1<<17) + " ").replace(/\*+$/, "")
```

ridiculously takes more than 10 seconds to be evaluated.

The patch was ported from the original markdown-it at the above commit.

Please refer to https://github.com/tats-u/markdown-exit/pull/1 for the record of struggles with Copilot. I don't think the content changes much even without using Copilot.

You might want to enable Dependabot alert and Private vulnerability reporting from Settings → Advanced Security to detect vulnerabilities in dependencies (I think this repository has used markdown-it for test) and let us submit such PRs privately.

<img width="1124" height="800" alt="image" src="https://github.com/user-attachments/assets/763c5df7-3660-45b3-aaf4-cf2784ec47ce" />


