### PR TITLE
fix: renderAsync honors monkey-patched renderer.render

### DIFF
--- a/packages/markdown-exit/src/renderer.ts
+++ b/packages/markdown-exit/src/renderer.ts
@@ -408,8 +408,17 @@ export class Renderer {
   /**
    * Async version of {@link Renderer.render}. Runs all render rules in parallel
    * (Promise.all) and preserves output order.
+   *
+   * If `render` has been overridden or monkey-patched on this instance — a
+   * common plugin pattern in the markdown-it ecosystem (e.g. @mdit-vue) — the
+   * wrapper is honored by falling back to the sync path, so patched logic is
+   * not silently bypassed. Async rules still throw there, as with `render()`.
    */
   async renderAsync(tokens: Token[], options: RenderOptions, env?: any): Promise<string> {
+    if (this.render !== Renderer.prototype.render) {
+      return this.render(tokens, options, env)
+    }
+
     const tasks: Array<Promise<string>> = []
     const rules = this.rules
 

--- a/packages/markdown-exit/tests/renderer.test.ts
+++ b/packages/markdown-exit/tests/renderer.test.ts
@@ -79,6 +79,38 @@ describe('renderAsync', () => {
       highlight: asyncHighlight,
     })).toThrow()
   })
+
+  it('honors a monkey-patched render method', async () => {
+    const md = createMarkdownExit()
+    const original = md.renderer.render.bind(md.renderer)
+    md.renderer.render = (tokens, options, env) => {
+      env!.patched = 'yes'
+      return original(tokens, options, env)
+    }
+
+    const env: Record<string, unknown> = {}
+    const html = await md.renderAsync('# hi', env)
+    expect(env.patched).toBe('yes')
+    expect(html).toBe('<h1>hi</h1>\n')
+  })
+
+  it('runs the parallel path when render is not patched', async () => {
+    const md = createMarkdownExit()
+    const env: Record<string, unknown> = {}
+    const html = await md.renderAsync('# hi', env)
+    expect(html).toBe('<h1>hi</h1>\n')
+    expect(env.patched).toBeUndefined()
+  })
+
+  it('patched render with an async rule surfaces the async-rule error', async () => {
+    const md = createMarkdownExit({
+      highlight: async str => `<b>${str}</b>`,
+    })
+    const original = md.renderer.render.bind(md.renderer)
+    md.renderer.render = (tokens, options, env) => original(tokens, options, env)
+
+    await expect(md.renderAsync('```\nhl\n```')).rejects.toThrow(/async rule detected/)
+  })
 })
 
 /**


### PR DESCRIPTION
Fixes #33

## Problem

`renderAsync()` calls `renderer.renderAsync()` directly, while `render()` goes through `renderer.render()`. Plugins that monkey-patch `md.renderer.render` — a widespread markdown-it ecosystem pattern, e.g. `@mdit-vue/plugin-headers` (used by VitePress to extract page headers into `env`) — are silently bypassed under `renderAsync()`, and their `env` writes never happen.

## Fix

`Renderer.renderAsync` now detects whether `render` has been overridden or monkey-patched on the instance (`this.render !== Renderer.prototype.render`) and delegates to it, so patched logic applies on the async path too.

Trade-off, made explicit: on the delegated sync path, async rules still throw the descriptive `async rule detected` error — same behavior as `render()`. Plugins that patch `render` are synchronous collectors by nature, so this combination is rare; when it does happen, the error message points the way.

## Tests

Three new tests in `tests/renderer.test.ts`:

- `renderAsync` honors a monkey-patched `render` (env write lands, output correct)
- the parallel path still runs when `render` is untouched
- a patched `render` combined with an async rule still surfaces the async-rule error

Full suite: 963 passed (960 baseline + 3 new), lint clean.